### PR TITLE
Feature/rename range condition objects trng 1251

### DIFF
--- a/Runtime/Conditions/PositionalConditions/ObjectInRangeCondition.cs
+++ b/Runtime/Conditions/PositionalConditions/ObjectInRangeCondition.cs
@@ -23,14 +23,14 @@ namespace Innoactive.Creator.Core.Conditions
             /// The object to measure distance from.
             /// </summary>
             [DataMember]
-            [DisplayName("First object")]
+            [DisplayName("Reference object")]
             public SceneObjectReference DistanceDetector { get; set; }
 
             /// <summary>
             /// The tracked object.
             /// </summary>
             [DataMember]
-            [DisplayName("Second object")]
+            [DisplayName("Tracked Object")]
             public SceneObjectReference Target { get; set; }
 
             /// <summary>

--- a/Runtime/Conditions/PositionalConditions/ObjectInRangeCondition.cs
+++ b/Runtime/Conditions/PositionalConditions/ObjectInRangeCondition.cs
@@ -30,7 +30,7 @@ namespace Innoactive.Creator.Core.Conditions
             /// The tracked object.
             /// </summary>
             [DataMember]
-            [DisplayName("Tracked Object")]
+            [DisplayName("Tracked object")]
             public SceneObjectReference Target { get; set; }
 
             /// <summary>


### PR DESCRIPTION
### Description
Renaming the 2 objects used in the Object Nearby Condition.

First object -> Reference object
Second object -> Tracked object

**Fixes**: # TRNG-1251

### Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update